### PR TITLE
Add NestJS integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,34 @@ app.listen(PORT, () => {
 });
 ```
 
+## Integrating with NestJS
+NestJS applications can use the same middleware approach because they run on Express by default. Add the middleware in `main.ts`:
+```typescript
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { RoundRobinLoadBalancer, proxyMiddleware } from 'node-load-balancer';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  const serverUrls = [
+    'http://server1',
+    'http://server2',
+    'http://server3',
+  ];
+
+  const loadBalancer = new RoundRobinLoadBalancer(serverUrls);
+
+  app.use(proxyMiddleware(loadBalancer));
+
+  await app.listen(3000);
+}
+bootstrap();
+```
+You can also look at `examples/nestjs/main.ts` for a complete example.
+
 ## Contributing
 Contributions are welcome! Please fork the repository and create a pull request with your enhancements or bug fixes.
 
 ## License
 This project is licensed under the MIT License - see the LICENSE file for details.
-```css
-
-```

--- a/examples/nestjs/main.ts
+++ b/examples/nestjs/main.ts
@@ -1,0 +1,24 @@
+import { NestFactory } from '@nestjs/core';
+import { Module } from '@nestjs/common';
+import { RoundRobinLoadBalancer } from '../../src/loadBalancers/RoundRobinLoadBalancer';
+import { proxyMiddleware } from '../../src/middlewares/proxyMiddleware';
+
+@Module({})
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  const serverUrls = [
+    { url: 'http://server1', isActive: true },
+    { url: 'http://server2', isActive: true },
+    { url: 'http://server3', isActive: true },
+  ];
+
+  const loadBalancer = new RoundRobinLoadBalancer(serverUrls);
+  app.use(proxyMiddleware(loadBalancer));
+
+  await app.listen(3000);
+}
+bootstrap();
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './loadBalancers/RoundRobinLoadBalancer';
 export * from './loadBalancers/WeightedRoundRobinLoadBalancer';
 export * from './loadBalancers/IPHashLoadBalancer';
+export * from './middlewares/proxyMiddleware';


### PR DESCRIPTION
## Summary
- export `proxyMiddleware`
- document using the library in NestJS applications
- add a NestJS integration example

## Testing
- `npm test`