### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,5 +23,18 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
-      - name: Test
-        run: npm test
+      - name: Test and generate coverage
+        run: npm run coverage
+      - name: Create coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/cobertura-coverage.xml
+          badge: true
+          format: markdown
+          output: both
+      - name: Add coverage PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -38,3 +42,4 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 .vscode/
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,8 @@ module.exports = {
     transform: {
       '^.+\\.tsx?$': 'ts-jest',
     },
-    testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  };
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['json-summary', 'lcov', 'text', 'cobertura'],
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "build": "tsc",
     "test": "jest",
+    "coverage": "jest --coverage",
     "run-round-robin-example": "grunt shell:startRoundRobinExample",
     "run-weighted-round-robin-example": "grunt shell:startWeightedRoundRobinExample",
     "run-ip-hash-example": "grunt shell:startIPHashExample"


### PR DESCRIPTION
## Summary
- generate coverage data with Jest
- ignore local coverage output
- add script for coverage run
- update PR workflow to comment coverage results

## Testing
- `npm test`
- `npm run coverage`
- `npm run lint`
- `npm run build`