### PR TITLE
Refactor load balancers to share server management

### DIFF
--- a/src/loadBalancers/BaseLoadBalancer.ts
+++ b/src/loadBalancers/BaseLoadBalancer.ts
@@ -1,0 +1,40 @@
+import { ILoadBalancer, IServer } from 'node-load-balancer';
+
+export abstract class BaseLoadBalancer<T extends IServer> implements ILoadBalancer {
+    protected servers: T[];
+
+    constructor(servers: T[]) {
+        this.servers = servers;
+    }
+
+    abstract getNextActiveServer(): T | null;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    addServer(url: string, _weight?: number): void {
+        this.servers.push({ url, isActive: true } as T);
+    }
+
+    removeServer(url: string): void {
+        const serverIndex = this.servers.findIndex((server: T) => server.url === url);
+
+        if (serverIndex !== -1) {
+            this.servers.splice(serverIndex, 1);
+        }
+    }
+
+    disableServer(url: string): void {
+        const server = this.servers.find((server: T) => server.url === url);
+
+        if (server) {
+            server.isActive = false;
+        }
+    }
+
+    enableServer(url: string): void {
+        const server = this.servers.find((server: T) => server.url === url);
+
+        if (server) {
+            server.isActive = true;
+        }
+    }
+}

--- a/src/loadBalancers/IPHashLoadBalancer.ts
+++ b/src/loadBalancers/IPHashLoadBalancer.ts
@@ -1,11 +1,11 @@
 import { IIPHashLoadBalancer, IServer } from 'node-load-balancer';
+import { BaseLoadBalancer } from './BaseLoadBalancer';
 
 /**
  * Represents an IP hash load balancer that distributes incoming requests unevenly across backend servers.
  * The client’s IP address is hashed and the hash is used to determine which server to send the request to.
  */
-export class IPHashLoadBalancer implements IIPHashLoadBalancer {
-    private servers: IServer[] = [];
+export class IPHashLoadBalancer extends BaseLoadBalancer<IServer> implements IIPHashLoadBalancer {
     private currentIndex = 0;
 
     /**
@@ -13,7 +13,7 @@ export class IPHashLoadBalancer implements IIPHashLoadBalancer {
      * @param servers - An array of backend servers to send the requests across.
      */
     constructor(servers: IServer[]) {
-        this.servers = servers;
+        super(servers);
     }
 
     /**
@@ -30,50 +30,6 @@ export class IPHashLoadBalancer implements IIPHashLoadBalancer {
         const server = activeServers[this.currentIndex];
         this.currentIndex = (this.currentIndex + 1) % activeServers.length;
         return server;
-    }
-
-    /**
-     * Adds a new server based on on the IP hash logic.
-     * @param url - The URL of the new server that is going to be added to the array.
-     */
-    addServer(url: string): void {
-        this.servers.push({ url, isActive: true });
-    }
-
-    /**
-     * Removes a server based on the IP hash logic.
-     * @param url - The URL of the server that is going to be removed from the array.
-     */
-    removeServer(url: string): void {
-        const serverIndex = this.servers.findIndex((server: IServer) => server.url === url);
-
-        if (serverIndex !== -1) {
-            this.servers.splice(serverIndex, 1);
-        }
-    }
-
-    /**
-     * Disables a server from the list of active ones but does not remove it.
-     * @param url - The URL of the server that needs to be tagged as inactive.
-     */
-    disableServer(url: string): void {
-        const server = this.servers.find((server: IServer) => server.url === url);
-
-        if (server) {
-            server.isActive = false;
-        }
-    }
-
-    /**
-     * Enables a server that was previously disabled.
-     * @param url - The URL of the server that needs to be tagged as active.
-     */
-    enableServer(url: string): void {
-        const server = this.servers.find((server: IServer) => server.url === url);
-
-        if (server) {
-            server.isActive = true;
-        }
     }
 
     /**

--- a/src/loadBalancers/RoundRobinLoadBalancer.ts
+++ b/src/loadBalancers/RoundRobinLoadBalancer.ts
@@ -1,12 +1,12 @@
 import { ILoadBalancer, IServer } from 'node-load-balancer';
+import { BaseLoadBalancer } from './BaseLoadBalancer';
 
 /**
  * Represents a round-robin load balancer that distributes incoming requests evenly across backend servers.
  * Distributes the traffic to the load balancers in rotation, each request going to the next backend server in the list.
  * Once the end of the list is reached, it loops back to the first server.
  */
-export class RoundRobinLoadBalancer implements ILoadBalancer {
-    private servers: IServer[] = [];
+export class RoundRobinLoadBalancer extends BaseLoadBalancer<IServer> implements ILoadBalancer {
     private currentIndex = 0;
 
     /**
@@ -14,7 +14,7 @@ export class RoundRobinLoadBalancer implements ILoadBalancer {
      * @param servers - An array of backend servers to balance the requests across.
      */
     constructor(servers: IServer[]) {
-        this.servers = servers;
+        super(servers);
     }
 
     /**
@@ -36,49 +36,5 @@ export class RoundRobinLoadBalancer implements ILoadBalancer {
         const server = activeServers[this.currentIndex];
         this.currentIndex = (this.currentIndex + 1) % activeServers.length;
         return server;
-    }
-
-    /**
-     * Adds a new server based on the round-robin logic.
-     * @param url - The URL of the new server that is going to be added to the array.
-     */
-    addServer(url: string): void {
-        this.servers.push({ url, isActive: true });
-    }
-
-    /**
-     * Removes a server based on the round-robin logic.
-     * @param url - The URL of the server that is going to be removed from the array.
-     */
-    removeServer(url: string) {
-        const serverIndex = this.servers.findIndex((server: IServer) => server.url === url);
-
-        if (serverIndex !== -1) {
-            this.servers.splice(serverIndex, 1);
-        }
-    }
-
-    /**
-     * Disables a server from the list of active ones but does not remove it.
-     * @param url - The URL of the server that needs to be tagged as inactive.
-     */
-    disableServer(url: string): void {
-        const server = this.servers.find((server: IServer) => server.url === url);
-
-        if (server) {
-            server.isActive = false;
-        }
-    }
-
-    /**
-     * Enables a server that was previously disabled.
-     * @param url - The URL of the server that needs to be tagged as active.
-     */
-    enableServer(url: string): void {
-        const server = this.servers.find((server: IServer) => server.url === url);
-
-        if (server) {
-            server.isActive = true;
-        }
     }
 }

--- a/src/loadBalancers/WeightedRoundRobinLoadBalancer.ts
+++ b/src/loadBalancers/WeightedRoundRobinLoadBalancer.ts
@@ -1,11 +1,14 @@
 import { IWeightedRoundRobinLoadBalancer, IWeightedServer } from 'node-load-balancer';
+import { BaseLoadBalancer } from './BaseLoadBalancer';
 
 /**
  * Represents a weighted round-robin load balancer that distributes incoming requests unevenly across backend servers.
  * Each server is given a weight, allowing some servers to receive more of the traffic than others.
  */
-export class WeightedRoundRobinLoadBalancer implements IWeightedRoundRobinLoadBalancer {
-    private servers: IWeightedServer[] = [];
+export class WeightedRoundRobinLoadBalancer
+    extends BaseLoadBalancer<IWeightedServer>
+    implements IWeightedRoundRobinLoadBalancer
+{
     private remainingServerCapacity: Array<{ server: IWeightedServer; capacity: number }> = [];
     private currentIndex = 0;
 
@@ -17,7 +20,7 @@ export class WeightedRoundRobinLoadBalancer implements IWeightedRoundRobinLoadBa
      * @param servers - An array of backend servers to send the requests across.
      */
     constructor(servers: IWeightedServer[]) {
-        this.servers = servers;
+        super(servers);
     }
 
     /**
@@ -87,37 +90,9 @@ export class WeightedRoundRobinLoadBalancer implements IWeightedRoundRobinLoadBa
      * @param url - The URL of the server that is going to be removed from the array.
      */
     removeServer(url: string): void {
-        const serverIndex = this.servers.findIndex((server: IWeightedServer) => server.url === url);
-
-        if (serverIndex !== -1) {
-            this.servers.splice(serverIndex, 1);
-            this.remainingServerCapacity = [];
-            this.currentIndex = 0;
-        }
-    }
-
-    /**
-     * Disables a server from the list of active ones but does not remove it.
-     * @param url - The URL of the server that needs to be tagged as inactive.
-     */
-    disableServer(url: string): void {
-        const server = this.servers.find((server: IWeightedServer) => server.url === url);
-
-        if (server) {
-            server.isActive = false;
-        }
-    }
-
-    /**
-     * Enables a server that was previously disabled.
-     * @param url - The URL of the server that needs to be tagged as active.
-     */
-    enableServer(url: string): void {
-        const server = this.servers.find((server: IWeightedServer) => server.url === url);
-
-        if (server) {
-            server.isActive = true;
-        }
+        super.removeServer(url);
+        this.remainingServerCapacity = [];
+        this.currentIndex = 0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- extract common server lifecycle methods into `BaseLoadBalancer`
- extend each load balancer from the new base class
- clean up class implementations

## Testing
- `npm run lint`
- `npm run build`
- `npm test`